### PR TITLE
CICD-12529: Add SONAR_SKIP condition to SonarQube scan

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -35,6 +35,7 @@ jobs:
 
       - name: SonarQube Scan
         uses: sonarsource/sonarqube-scan-action@v5
+        if: vars.SONAR_SKIP != 'TRUE'
         env:
           SONAR_TOKEN: ${{ secrets.SONARQUBE_PUBLIC_API_KEY }}
           SONAR_HOST_URL: https://sonarqube.collibra.dev


### PR DESCRIPTION
## CICD-12529: Add SONAR_SKIP condition to SonarQube scan

This PR adds an `if: vars.SONAR_SKIP != 'TRUE'` condition to all `sonarsource/sonarqube-scan-action` steps in this repository's workflows.

When the org-level variable `SONAR_SKIP` is set to `TRUE`, the SonarQube scan step will be skipped. Otherwise it runs as normal.

### Files changed

- `.github/workflows/build.yml`

---
*Automated change by CICD-12529 script*
