### PR TITLE
CICD-13444 Pin GitHub Actions to approved SHAs (main)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,7 +26,7 @@ jobs:
         run: make build
 
       - name: Lint
-        uses: golangci/golangci-lint-action@v8
+        uses: golangci/golangci-lint-action@4afd733a84b1f43292c63897423277bb7f4313a9  # v8
         with:
           version: v2.4.0
 
@@ -34,7 +34,7 @@ jobs:
         run: make test-coverage
 
       - name: SonarQube Scan
-        uses: sonarsource/sonarqube-scan-action@v5
+        uses: sonarsource/sonarqube-scan-action@2f77a1ec69fb1d595b06f35ab27e97605bdef703  # v5
         env:
           SONAR_TOKEN: ${{ secrets.SONARQUBE_PUBLIC_API_KEY }}
           SONAR_HOST_URL: https://sonarqube.collibra.dev
@@ -51,6 +51,6 @@ jobs:
 #          SONAR_HOST_URL: https://sonarqube.collibra.dev
 
       - name: FOSSA Scan
-        uses: fossas/fossa-action@v1
+        uses: fossas/fossa-action@ff70fe9fe17cbd2040648f1c45e8ec4e4884dcf3  # v1
         with:
           api-key: ${{ secrets.FOSSA_PUBLIC_API_KEY }}


### PR DESCRIPTION
## Pin GitHub Actions to approved SHAs

This PR was generated by `pin_actions_in_repos.py` to replace tag-pinned
Actions with their approved SHA equivalents from the
[Collibra Actions allow-list](https://github.com/collibra/cicd-github-management/blob/main/github-actions-allow-list/source-of-truth.yml).

### Changed files
- `.github/workflows/build.yml`

Each `uses:` line is updated to pin the full commit SHA, with the original
tag preserved as a comment for human readability.

---
*Ticket: [CICD-13444](https://collibra.atlassian.net/browse/CICD-13444)*


[CICD-13444]: https://engineering-collibra.atlassian.net/browse/CICD-13444?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ